### PR TITLE
Ft fetch course modules

### DIFF
--- a/src/components/ExpansionPanel/ExpansionPanel.jsx
+++ b/src/components/ExpansionPanel/ExpansionPanel.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import PropTypes from "prop-types";
 import { withStyles } from "@material-ui/core/styles";
@@ -23,60 +24,13 @@ const CourseExpansionPanel = (props) => {
     <div className={classes.root}>
       <ExpansionPanel>
         <ExpansionPanelSummary expandIcon={<ExpandMoreIcon />}>
-          <Typography className={classes.heading}>Course Overview</Typography>
+          <Typography className={classes.heading}>{props.module_title}</Typography>
         </ExpansionPanelSummary>
-        <ExpansionPanelDetails>
-          <Typography className={classes.heading}>
+        <ExpansionPanelDetails className={classes.heading}>
           <ul>
-            <li><a href="/" style={{ color: "inherit", textDecoration: "underline" }}>Beginning course(1m 05s)</a></li>
-            <li><a href="/" style={{ color: "inherit", textDecoration: "underline" }}>Learning the basics(5m 05s)</a></li>
-            <li><a href="/" style={{ color: "inherit", textDecoration: "underline" }}>Working with files(15m 00s)</a></li>
-            </ul>
+            <li><a href="/" style={{ color: "inherit", textDecoration: "underline" }}>{props.module_content}</a></li>
 
-          </Typography>
-        </ExpansionPanelDetails>
-      </ExpansionPanel>
-      <ExpansionPanel>
-        <ExpansionPanelSummary expandIcon={<ExpandMoreIcon />}>
-          <Typography className={classes.heading}>Introduction to course</Typography>
-        </ExpansionPanelSummary>
-        <ExpansionPanelDetails>
-          <Typography className={classes.heading}>
-            <ul>
-            <li><a href="/" style={{ color: "inherit", textDecoration: "underline" }}>Beginning course(1m 05s)</a></li>
-            <li><a href="/" style={{ color: "inherit", textDecoration: "underline" }}>Learning the basics(5m 05s)</a></li>
-            <li><a href="/" style={{ color: "inherit", textDecoration: "underline" }}>Working with files(15m 00s)</a></li>
             </ul>
-
-          </Typography>
-        </ExpansionPanelDetails>
-      </ExpansionPanel>
-      <ExpansionPanel>
-        <ExpansionPanelSummary expandIcon={<ExpandMoreIcon />}>
-          <Typography className={classes.heading}>Deep Dive into the fundamentals</Typography>
-        </ExpansionPanelSummary>
-        <ExpansionPanelDetails>
-          <Typography className={classes.heading}>
-            <ul>
-            <li><a href="/" style={{ color: "inherit", textDecoration: "underline" }}>Beginning course(1m 05s)</a></li>
-            <li><a href="/" style={{ color: "inherit", textDecoration: "underline" }}>Learning the basics(5m 05s)</a></li>
-            <li><a href="/" style={{ color: "inherit", textDecoration: "underline" }}>Working with files(15m 00s)</a></li>
-            </ul>
-          </Typography>
-        </ExpansionPanelDetails>
-      </ExpansionPanel>
-      <ExpansionPanel>
-        <ExpansionPanelSummary expandIcon={<ExpandMoreIcon />}>
-          <Typography className={classes.heading}>Conclusion</Typography>
-        </ExpansionPanelSummary>
-        <ExpansionPanelDetails>
-          <Typography className={classes.heading}>
-            <ul>
-            <li><a href="/" style={{ color: "inherit", textDecoration: "underline" }}>Beginning course(1m 05s)</a></li>
-            <li><a href="/" style={{ color: "inherit", textDecoration: "underline" }}>Learning the basics(5m 05s)</a></li>
-            <li><a href="/" style={{ color: "inherit", textDecoration: "underline" }}>Working with files(15m 00s)</a></li>
-            </ul>
-          </Typography>
         </ExpansionPanelDetails>
       </ExpansionPanel>
     </div>

--- a/src/components/ExpansionPanel/ExpansionPanel.jsx
+++ b/src/components/ExpansionPanel/ExpansionPanel.jsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/prop-types */
-import React from "react";
+import React, { useState } from "react";
 import PropTypes from "prop-types";
 import { withStyles } from "@material-ui/core/styles";
 import ExpansionPanel from "@material-ui/core/ExpansionPanel";
@@ -7,6 +7,8 @@ import ExpansionPanelSummary from "@material-ui/core/ExpansionPanelSummary";
 import ExpansionPanelDetails from "@material-ui/core/ExpansionPanelDetails";
 import Typography from "@material-ui/core/Typography";
 import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
+import axios from "axios";
+import ModuleContent from "../ModuleContent/ModuleContent.jsx";
 
 const styles = (theme) => ({
   root: {
@@ -19,18 +21,27 @@ const styles = (theme) => ({
 });
 
 const CourseExpansionPanel = (props) => {
+  const [moduleContent, setModuleContent] = useState([]);
+  const { REACT_APP_BASE_URL } = process.env;
+
+
   const { classes } = props;
+  const handlePanelClick = () => {
+    axios
+      .get(`${REACT_APP_BASE_URL}/api/v1/modules/${props.id}`)
+      .then((res) => {
+        setModuleContent(res.data.modules);
+      })
+      .catch((err) => err);
+  };
   return (
     <div className={classes.root}>
-      <ExpansionPanel>
+      <ExpansionPanel onClick={handlePanelClick}>
         <ExpansionPanelSummary expandIcon={<ExpandMoreIcon />}>
           <Typography className={classes.heading}>{props.module_title}</Typography>
         </ExpansionPanelSummary>
         <ExpansionPanelDetails className={classes.heading}>
-          <ul>
-            <li><a href="/" style={{ color: "inherit", textDecoration: "underline" }}>{props.module_content}</a></li>
-
-            </ul>
+        <ModuleContent module_id={props.id} moduleData={moduleContent} />
         </ExpansionPanelDetails>
       </ExpansionPanel>
     </div>

--- a/src/components/ModuleContent/ModuleContent.jsx
+++ b/src/components/ModuleContent/ModuleContent.jsx
@@ -1,0 +1,14 @@
+/* eslint-disable react/prop-types */
+import React from "react";
+
+const ModuleContent = (props) => (<div>
+  <ul>
+    {props.moduleData.length > 0 ? props.moduleData.map((module, index) => (
+        <li key={index}>
+        <a href="/modules/">{module.module_content_title}</a>
+      </li>
+    )) : <li>No module content yet for this module</li>}
+  </ul>
+</div>);
+
+export default ModuleContent;

--- a/src/components/SingleCourse/SingleCourse.jsx
+++ b/src/components/SingleCourse/SingleCourse.jsx
@@ -42,13 +42,12 @@ export const SingleCourse = (props) => {
 
             <p className="mt-4"><a href="#" className="btn btn-primary">Enroll</a></p>
           </div>
-          {props.modules.data.message
+          {props.modules.data && props.modules.data.message
             ? props.modules.data.message.map((module) => (
               <div key={module.module_id}>
                 <CourseExpansionPanel
                 id = {module.module_id}
                 course_id = {module.course_id}
-                module_content = {module.module_content}
                 module_date_added = {module.module_date_added}
                 module_description = {module.module_description}
                 module_title = {module.module_title}

--- a/src/components/SingleCourse/SingleCourse.jsx
+++ b/src/components/SingleCourse/SingleCourse.jsx
@@ -1,11 +1,12 @@
 /* eslint-disable react/prop-types */
 /* eslint-disable import/prefer-default-export */
 import React from "react";
-import CourseExpansionPanel from "../ExpansionPanel/ExpansionPanel.jsx";
 import Footer from "../Footer/Footer.jsx";
 import Header from "../Header/Header.jsx";
 import SrcImg4 from "../../assets/images/undraw_youtube_tutorial.svg";
 import { capitalize } from "./utils";
+import CourseExpansionPanel from "../ExpansionPanel/ExpansionPanel.jsx";
+
 
 export const SingleCourse = (props) => {
   const isAuthenticated = localStorage.getItem("token");
@@ -41,7 +42,19 @@ export const SingleCourse = (props) => {
 
             <p className="mt-4"><a href="#" className="btn btn-primary">Enroll</a></p>
           </div>
-          <CourseExpansionPanel />
+          {props.modules.data.message
+            ? props.modules.data.message.map((module) => (
+              <div key={module.module_id}>
+                <CourseExpansionPanel
+                id = {module.module_id}
+                course_id = {module.course_id}
+                module_content = {module.module_content}
+                module_date_added = {module.module_date_added}
+                module_description = {module.module_description}
+                module_title = {module.module_title}
+                />
+                </div>
+            )) : null}
           <div className="pt-5">
             <h3 className="mb-5">Discussion</h3>
             <ul className="comment-list">

--- a/src/containers/SingleCourseContainer.jsx
+++ b/src/containers/SingleCourseContainer.jsx
@@ -3,25 +3,21 @@ import React, { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { SingleCourse } from "../components/SingleCourse";
 import fetchSingleCourseAction from "../redux/actions/fetchSingleCourseAction.jsx";
+import fetchCourseModulesAction from "../redux/actions/fetchCourseModulesAction.jsx";
 
 const SingleCourseContainer = (props) => {
   const dispatch = useDispatch();
   const singleCourseData = useSelector((state) => state.fetchSingleCourseReducer);
+  const courseModuleData = useSelector((state) => state.fetchCourseModuleReducer);
   useEffect(() => {
     dispatch(fetchSingleCourseAction(props.match.params.id));
+    dispatch(fetchCourseModulesAction(props.match.params.id));
   }, []);
-
-
-  // useEffect(() => {
-  //   if (singleCourseData.data.course) {
-  //     props.history.push(`/courses/${props.match.params.id}`);
-  //   }
-  // }, [singleCourseData]);
 
 
   return (
         <div>
-        <SingleCourse data={singleCourseData} />
+        <SingleCourse data={singleCourseData} modules={courseModuleData} />
     </div>
   );
 };

--- a/src/redux/actions/actionTypes.jsx
+++ b/src/redux/actions/actionTypes.jsx
@@ -37,3 +37,13 @@ export const fetchSingleCourseFail = (error) => ({
   type: "FETCH_SINGLE_COURSE_FAIL",
   error
 });
+
+export const fetchCourseModuleSuccess = (payload) => ({
+  type: "FETCH_COURSE_MODULE_SUCCESS",
+  payload
+});
+
+export const fetchCourseModulesFail = (error) => ({
+  type: "FETCH_COURSE_MODULE_FAIL",
+  error
+});

--- a/src/redux/actions/fetchCourseModulesAction.jsx
+++ b/src/redux/actions/fetchCourseModulesAction.jsx
@@ -1,0 +1,24 @@
+import * as actions from "./actionTypes.jsx";
+
+
+const { REACT_APP_BASE_URL } = process.env;
+
+
+const fetchCourseModulesAction = (id) => (dispatch) => fetch(`${REACT_APP_BASE_URL}/api/v1/courses/${id}/modules`, {
+  method: "GET",
+  headers: {
+    "Content-Type": "application/json"
+  },
+  mode: "cors"
+})
+  .then((response) => response.json())
+  .then((json) => {
+    if (typeof json.message === "object") {
+      dispatch(actions.fetchCourseModuleSuccess(json));
+    } else {
+      dispatch(actions.fetchCourseModulesFail(json));
+    }
+  })
+  .catch((err) => err);
+
+export default fetchCourseModulesAction;

--- a/src/redux/reducers/combinedReducer.jsx
+++ b/src/redux/reducers/combinedReducer.jsx
@@ -3,11 +3,13 @@ import loginReducer from "./loginReducer.jsx";
 import signUpReducer from "./signUpReducer.jsx";
 import fetchCoursesReducer from "./fetchCoursesReducer.jsx";
 import fetchSingleCourseReducer from "./fetchSingleCourseReducer.jsx";
+import fetchCourseModuleReducer from "./fetchCourseModuleReducer.jsx";
 
 
 export default combineReducers({
   loginReducer,
   signUpReducer,
   fetchCoursesReducer,
-  fetchSingleCourseReducer
+  fetchSingleCourseReducer,
+  fetchCourseModuleReducer
 });

--- a/src/redux/reducers/fetchCourseModuleReducer.jsx
+++ b/src/redux/reducers/fetchCourseModuleReducer.jsx
@@ -1,0 +1,23 @@
+const initialState = {
+  data: {}, error: {}
+};
+
+const fetchCourseModuleReducer = (state = initialState, action) => {
+  switch (action.type) {
+    case "FETCH_COURSE_MODULE_SUCCESS":
+      return {
+        ...state,
+        data: action.payload
+      };
+    case "FETCH_COURSE_MODULE_FAIL":
+      return {
+        ...state,
+        error: action.error
+      };
+    default:
+      return {
+        ...state
+      };
+  }
+};
+export default fetchCourseModuleReducer;


### PR DESCRIPTION
## Description
- Displays course modules and their content at the frontend.

Fixes #31 

## How Has This Been Tested?
- Fetch the branch `git fetch origin ft-fetch-course-modules`
- Checkout the branch `git checkout ft-fetch-course-modules`
- Start the local server `yarn start-dev`
- Navigate to `http://localhost:3000`
- Click on any course on the dashboard to view its page
- Check the modules section to view the available modules

## Checklist:
<!--- Put an `x` in all the boxes that apply ! -->
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added necessary inline code documentation
- [ ] I have added tests that prove my fix is effective and that this feature works
- [ ] New and existing unit tests pass locally with my changes
