### PR TITLE
Added ability to delete, add new and view partner Organisations by admin

### DIFF
--- a/src/components/AdminPanel/Content/Partnerships.jsx
+++ b/src/components/AdminPanel/Content/Partnerships.jsx
@@ -1,9 +1,150 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { Table } from "react-bootstrap";
+import PaginationRow from "../../Pagination/PaginationRow.jsx";
+import OrganizationModal from "../../Modal/OrganizationModal.jsx";
+import AddOrganizationContainer from "../../../containers/AddOrganizationContainer.jsx";
+import deleteOrganizationAction from "../../../redux/actions/deleteOrganizationAction.jsx";
+import fetchOrganizationsAction from "../../../redux/actions/fetchOrganizationsAction.jsx";
 
+const LIMIT = 6;
+const Partnerships = () => {
+  const dispatch = useDispatch();
 
-const Partnerships = () => (
-        <div>
-            Partnerships
-        </div>
-);
+  const OrganizationData = useSelector((state) => state.fetchOrganizationsReducer);
+  const filteredData = useSelector((state) => state.deleteOrganizationReducer);
+
+  const [activeRow, setActiveRow] = useState(0);
+  const [data, setData] = useState([]);
+  const [modalShow, setModalShow] = useState(false);
+  const [updateData, setUpdateData] = useState();
+
+  const [count, setCount] = useState(0);
+  const [pageCount, setPageCount] = useState(0);
+  const [currentPage, setCurrentPage] = useState(1);
+  const [selectedPage, setSelectedPage] = useState(0);
+
+  useEffect(() => {
+    dispatch(fetchOrganizationsAction());
+  }, []);
+
+  useEffect(() => {
+    if (OrganizationData.data.organizations) {
+      setData(OrganizationData.data.organizations);
+      setCount(OrganizationData.data.organizations.length);
+      setPageCount(Math.ceil(OrganizationData.data.organizations.length / LIMIT));
+    }
+  }, [OrganizationData]);
+
+  const handleView = (organizationID) => {
+    if (organizationID !== activeRow) {
+      setActiveRow(organizationID);
+      window.location.replace(`/organization/${organizationID}`);
+    }
+  };
+
+  const handleDelete = (organizationID) => {
+    setActiveRow(organizationID);
+    dispatch(deleteOrganizationAction(organizationID));
+  };
+
+  useEffect(() => {
+    if (filteredData.error.message === "Organization deleted!") {
+      setData(() => data.filter((item) => item.organization_id !== activeRow));
+    }
+  }, [filteredData]);
+
+  const handleEdit = (organizationID) => {
+    setActiveRow(organizationID);
+    setModalShow(true);
+    setUpdateData(() => data.filter((item) => item.organization_id === activeRow));
+  };
+
+  const handlePageChange = (page) => {
+    setSelectedPage(page.selected);
+    if (page.selected === selectedPage + 1) {
+      setCurrentPage(currentPage + 1);
+    } else if (page.selected === selectedPage - 1) {
+      setCurrentPage(currentPage - 1);
+    } else {
+      setCurrentPage(() => page.selected + 1);
+    }
+  };
+
+  const getDataByPage = () => {
+    const begin = (currentPage - 1) * LIMIT;
+    const end = begin + LIMIT;
+
+    return data.slice(begin, end);
+  };
+
+  const renderPagination = () =>
+    count === 0 ? (
+      "No Data"
+    ) : (
+      <PaginationRow limit={LIMIT} count={count} pageCount={pageCount} onPageChange={handlePageChange} />
+    );
+
+  return (
+    <div>
+      <Table responsive="md" hover size="sm" bordered striped width="100%" cellSpacing="0">
+        <thead>
+          <tr>
+            <th>ID</th>
+            <th>ORGANIZATION NAME</th>
+            <th>Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {getDataByPage()
+            ? getDataByPage().map((organization, index) => (
+                <tr
+                  key={organization.organization_id}
+                  style={{
+                    backgroundColor: activeRow === organization.organization_id ? "#ffd3d9" : ""
+                  }}
+                >
+                  <td>{currentPage * LIMIT + index + 1 - 5}</td>
+                  <td>{organization.organization_name}</td>
+                  <td>
+                    <button
+                      type="button"
+                      className="btn btn-sm btn-outline-primary"
+                      style={{ width: "60px", padding: "5px" }}
+                      onClick={() => handleView(organization.organization_id)}
+                    >
+                      View
+                    </button>
+                    <button
+                      type="button"
+                      className="btn btn-outline-secondary"
+                      style={{ width: "60px", padding: "5px" }}
+                      onClick={() => handleEdit(organization.organization_id)}
+                    >
+                      Edit
+                    </button>
+                    <button
+                      type="button"
+                      className="btn btn-outline-danger"
+                      style={{ width: "60px", padding: "5px" }}
+                      onClick={() => handleDelete(organization.organization_id)}
+                    >
+                      Delete
+                    </button>
+                    <OrganizationModal show={modalShow} onHide={() => setModalShow(false)} data={updateData} />
+                  </td>
+                </tr>
+              ))
+            : null}
+        </tbody>
+      </Table>
+      <div style={{ float: "right" }}>{renderPagination()}</div>
+      <br />
+      <br />
+      <div>
+        <AddOrganizationContainer />
+      </div>
+    </div>
+  );
+};
 export default Partnerships;

--- a/src/components/AdminPanel/Content/PartnershipsForm.jsx
+++ b/src/components/AdminPanel/Content/PartnershipsForm.jsx
@@ -1,0 +1,32 @@
+/* eslint-disable react/prop-types */
+import React from "react";
+
+const AddOrganization = (props) => (
+  <div className="card">
+    <h5 className="card-header info-color white-text text-center py-4">
+      <strong>Add New Organization</strong>
+    </h5>
+    <div className="card-body px-lg-5 pt-0">
+      <form className="text-center" style={{ color: "#757575" }} onSubmit={props.onSubmit}>
+        <div className="md-form mt-3">
+          <label htmlFor="organization_name">Organization Name</label>
+          <input
+            type="text"
+            name="organization_name"
+            id="materialContactFormName"
+            className="form-control"
+            placeholder="Organization Name"
+            onChange={props.onChange}
+            required
+          />
+        </div>
+
+        <button className="btn btn-outline-primary btn-rounded btn-block z-depth-0 my-4 waves-effect" type="submit">
+          Add partner Organisation
+        </button>
+      </form>
+    </div>
+  </div>
+);
+
+export default AddOrganization;

--- a/src/components/Modal/OrganizationModal.jsx
+++ b/src/components/Modal/OrganizationModal.jsx
@@ -1,0 +1,31 @@
+/* eslint-disable react/prop-types */
+import React from "react";
+import { Modal, Button } from "react-bootstrap";
+import { MDBInput } from "mdbreact";
+import "react-toastify/dist/ReactToastify.css";
+
+const OrganizationModal = (props) => (
+  <Modal size="lg" aria-labelledby="contained-modal-title-vcenter" centered>
+    <Modal.Header closeButton>
+      <Modal.Title id="contained-modal-title-vcenter">Update organisation</Modal.Title>
+    </Modal.Header>
+    <Modal.Body>
+      <form>
+        <div className="grey-text">
+          <MDBInput
+            label="Organization Name"
+            name="organization_name"
+            type="text"
+            onChange={props.onChange}
+            success="right"
+          />
+        </div>
+      </form>
+    </Modal.Body>
+    <Modal.Footer>
+      <Button onClick={() => props.handleSubmit(props.id)}>Update Organization</Button>
+      <Button onClick={props.onHide}>Close</Button>
+    </Modal.Footer>
+  </Modal>
+);
+export default OrganizationModal;

--- a/src/containers/AddOrganizationContainer.jsx
+++ b/src/containers/AddOrganizationContainer.jsx
@@ -1,0 +1,64 @@
+/* eslint camelcase: ["error", {properties: "never"}] */
+import React, { useEffect, useState } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { toast, ToastContainer } from "react-toastify";
+import "react-toastify/dist/ReactToastify.css";
+import AddOrganization from "../components/AdminPanel/Content/PartnershipsForm";
+import addOrganizationAction from "../redux/actions/addOrganizationAction.jsx";
+
+const AddOrganizationContainer = () => {
+  const [addOrganizationDetails, setAddOrganizationDetails] = useState({});
+  const dispatch = useDispatch();
+  const addOrganizationData = useSelector((state) => state.addOrganizationReducer);
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setAddOrganizationDetails((prevState) => ({ ...prevState, [name]: value }));
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    dispatch(addOrganizationAction(addOrganizationDetails));
+  };
+
+  const handleAddOrganizationSuccess = () => {
+    if (addOrganizationData.data) {
+      toast.success(<p className="text-white">Organization added successfully</p>);
+    }
+  };
+
+  const handleAddOrganizationFail = () => {
+    if (addOrganizationData.error) {
+      toast.error(<p>{addOrganizationData.error.message}</p>);
+    }
+  };
+
+  useEffect(() => {
+    if (addOrganizationData.data.message) {
+      handleAddOrganizationSuccess();
+    }
+    if (!addOrganizationData.data.message && addOrganizationData.error.message) {
+      handleAddOrganizationFail();
+    }
+  }, [addOrganizationData]);
+
+  return (
+    <div>
+      <AddOrganization onChange={handleChange} onSubmit={handleSubmit} />
+      {Object.keys(addOrganizationData.data).length === 0 &&
+      !Object.keys(addOrganizationData.error).length === 0 ? null : (
+        <ToastContainer
+          position="top-right"
+          hideProgressBar={false}
+          newestOnTop={true}
+          closeOnClick={false}
+          draggable={false}
+          rtl={false}
+          autoClose={1000}
+        />
+      )}
+    </div>
+  );
+};
+
+export default AddOrganizationContainer;

--- a/src/redux/actions/actionTypes.jsx
+++ b/src/redux/actions/actionTypes.jsx
@@ -107,3 +107,33 @@ export const enrollFail = (error) => ({
   type: "ENROLL_FAIL",
   error
 });
+
+export const addOrganizationSuccess = (payload) => ({
+  type: "ADD_ORGANIZATION_SUCCESS",
+  payload
+});
+
+export const addOrganizationFail = (error) => ({
+  type: "ADD_ORGANIZATION_FAIL",
+  error
+});
+
+export const deleteOrganizationSuccess = (payload) => ({
+  type: "DELETE_ORGANIZATION_SUCCESS",
+  payload
+});
+
+export const deleteOrganizationFail = (error) => ({
+  type: "DELETE_ORGANIZATION_FAIL",
+  error
+});
+
+export const fetchOrganizationsSuccess = (payload) => ({
+  type: "FETCH_ORGANIZATIONS_SUCCESS",
+  payload
+});
+
+export const fetchOrganizationsFail = (error) => ({
+  type: "FETCH_ORGANIZATIONS_FAIL",
+  error
+});

--- a/src/redux/actions/addOrganizationAction.jsx
+++ b/src/redux/actions/addOrganizationAction.jsx
@@ -1,0 +1,29 @@
+/* eslint-disable implicit-arrow-linebreak */
+/* eslint-disable linebreak-style */
+/* eslint-disable no-multiple-empty-lines */
+/* eslint-disable linebreak-style */
+import * as actions from "./actionTypes.jsx";
+
+const { REACT_APP_BASE_URL } = process.env;
+const token = localStorage.getItem("token");
+
+const addOrganizationAction = (payload) => (dispatch) =>
+  fetch(`${REACT_APP_BASE_URL}/api/v1/organizations`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`
+    },
+    mode: "cors",
+    body: JSON.stringify(payload)
+  })
+    .then((response) => response.json())
+    .then((json) => {
+      if (json.message === "organization added successfully") {
+        dispatch(actions.addOrganizationSuccess(json));
+      } else {
+        dispatch(actions.addOrganizationFail(json));
+      }
+    })
+    .catch((err) => err);
+export default addOrganizationAction;

--- a/src/redux/actions/deleteOrganizationAction.jsx
+++ b/src/redux/actions/deleteOrganizationAction.jsx
@@ -1,0 +1,25 @@
+import * as actions from "./actionTypes.jsx";
+
+const { REACT_APP_BASE_URL } = process.env;
+
+const token = localStorage.getItem("token");
+
+const deleteOrganizationAction = (id) => (dispatch) =>
+  fetch(`${REACT_APP_BASE_URL}/api/v1/organizations/${id}`, {
+    method: "DELETE",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`
+    },
+    mode: "cors"
+  })
+    .then((response) => response.json())
+    .then((json) => {
+      if (json.course) {
+        dispatch(actions.deleteOrganizationSuccess(json));
+      } else {
+        dispatch(actions.deleteOrganizationFail(json));
+      }
+    })
+    .catch((err) => err);
+export default deleteOrganizationAction;

--- a/src/redux/actions/fetchOrganizationsAction.jsx
+++ b/src/redux/actions/fetchOrganizationsAction.jsx
@@ -1,0 +1,24 @@
+import axios from "axios";
+import * as actions from "./actionTypes.jsx";
+
+const { REACT_APP_BASE_URL } = process.env;
+
+const fetchOrganizationsAction = () => (dispatch) =>
+  axios
+    .get(`${REACT_APP_BASE_URL}/api/v1/organizations`, {
+      headers: {
+        "Content-Type": "application/json"
+      },
+      mode: "cors"
+    })
+    .then(
+      (response) => {
+        if (response.data.organizations) {
+          dispatch(actions.fetchOrganizationsSuccess(response.data));
+        } else {
+          dispatch(actions.fetchOrganizationsFail(response.data));
+        }
+      },
+      (error) => error
+    );
+export default fetchOrganizationsAction;

--- a/src/redux/reducers/addOrganizationReducer.jsx
+++ b/src/redux/reducers/addOrganizationReducer.jsx
@@ -1,0 +1,24 @@
+const initialState = {
+  data: {},
+  error: {}
+};
+
+const addOrganizationReducer = (state = initialState, action) => {
+  switch (action.type) {
+    case "ADD_ORGANIZATION_SUCCESS":
+      return {
+        ...state,
+        data: action.payload
+      };
+    case "ADD_ORGANIZATION_FAIL":
+      return {
+        ...state,
+        error: action.error
+      };
+    default:
+      return {
+        ...state
+      };
+  }
+};
+export default addOrganizationReducer;

--- a/src/redux/reducers/combinedReducer.jsx
+++ b/src/redux/reducers/combinedReducer.jsx
@@ -10,6 +10,9 @@ import deleteCourseReducer from "./deleteCourseReducer.jsx";
 import addCourseReducer from "./addCourseReducer.jsx";
 import addCommentReducer from "./addCommentReducer.jsx";
 import enrollReducer from "./enrollReducer.jsx";
+import fetchOrganizationsReducer from "./fetchOrganizationsReducer.jsx";
+import addOrganizationReducer from "./addOrganizationReducer.jsx";
+import deleteOrganizationReducer from "./deleteOrganizationsReducer.jsx";
 
 export default combineReducers({
   loginReducer,
@@ -22,5 +25,8 @@ export default combineReducers({
   deleteCourseReducer,
   addCourseReducer,
   addCommentReducer,
-  enrollReducer
+  enrollReducer,
+  fetchOrganizationsReducer,
+  addOrganizationReducer,
+  deleteOrganizationReducer
 });

--- a/src/redux/reducers/deleteOrganizationsReducer.jsx
+++ b/src/redux/reducers/deleteOrganizationsReducer.jsx
@@ -1,0 +1,24 @@
+const initialState = {
+  data: {},
+  error: {}
+};
+
+const deleteOrganizationReducer = (state = initialState, action) => {
+  switch (action.type) {
+    case "DELETE_ORGANIZATION_SUCCESS":
+      return {
+        ...state,
+        data: action.payload
+      };
+    case "DELETE_ORGANIZATION_FAIL":
+      return {
+        ...state,
+        error: action.error
+      };
+    default:
+      return {
+        ...state
+      };
+  }
+};
+export default deleteOrganizationReducer;

--- a/src/redux/reducers/fetchOrganizationsReducer.jsx
+++ b/src/redux/reducers/fetchOrganizationsReducer.jsx
@@ -1,0 +1,24 @@
+const initialState = {
+  data: {},
+  error: {}
+};
+
+const fetchOrganizationsReducer = (state = initialState, action) => {
+  switch (action.type) {
+    case "FETCH_ORGANIZATIONS_SUCCESS":
+      return {
+        ...state,
+        data: action.payload
+      };
+    case "FETCH_ORGANISATIONS_FAIL":
+      return {
+        ...state,
+        error: action.error
+      };
+    default:
+      return {
+        ...state
+      };
+  }
+};
+export default fetchOrganizationsReducer;


### PR DESCRIPTION
## Description
ADMIN ABLE TO ADD NEW PARTNER ORGANIZATION, DELETE AND VIEW


FIXES ISSUE: #86, #87, #88

## How Has This Been Tested?
NOT YET ABLE TO EDIT ORGANIZATION, AND ALSO NEED TO RESOLVE EMPTY URL ON CLICKING VIEW ORGANIZATIOIN

## Screenshots (if applicable, else remove this line / section)
![image](https://user-images.githubusercontent.com/36305514/90288854-66807c80-de83-11ea-9752-4418a7a9f59b.png)


## Checklist:
<!--- Put an `x` in all the boxes that apply ! -->
- [X ] My code follows the style guidelines of this project
- [ X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added necessary inline code documentation
- [ ] I have added tests that prove my fix is effective and that this feature works
- [ ] New and existing unit tests pass locally with my changes
